### PR TITLE
Fixed XML loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-
-bin/Debug/test.xml

--- a/EditButtonForm.Designer.cs
+++ b/EditButtonForm.Designer.cs
@@ -71,9 +71,9 @@
             this.label1.ForeColor = System.Drawing.Color.White;
             this.label1.Location = new System.Drawing.Point(21, 48);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(32, 16);
+            this.label1.Size = new System.Drawing.Size(115, 16);
             this.label1.TabIndex = 7;
-            this.label1.Text = "Link";
+            this.label1.Text = "Link or full file path";
             // 
             // editDescriptionTextBox
             // 
@@ -97,6 +97,7 @@
             // 
             // EditButtonForm
             // 
+            this.AcceptButton = this.applyEditButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
@@ -106,6 +107,7 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.editDescriptionTextBox);
             this.Controls.Add(this.editLinkTextBox);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximumSize = new System.Drawing.Size(230, 300);
             this.MinimumSize = new System.Drawing.Size(230, 300);

--- a/EditButtonForm.cs
+++ b/EditButtonForm.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using EzLaunchr.Properties;
 
@@ -28,6 +21,7 @@ namespace EzLaunchr
         {
             lb.link = editLinkTextBox.Text;
             lb.displayName.Text = editDescriptionTextBox.Text;
+            this.Close();
 
         }
 

--- a/EzLaunchr.csproj
+++ b/EzLaunchr.csproj
@@ -129,7 +129,6 @@
     <EmbeddedResource Include="Scripts\LinkButton.resx">
       <DependentUpon>LinkButton.cs</DependentUpon>
     </EmbeddedResource>
-    <None Include="LoLAccountLookup_TemporaryKey.pfx" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -32,9 +32,13 @@
             this.OpenAllButton = new System.Windows.Forms.Button();
             this.flowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.createPanelButton = new System.Windows.Forms.Button();
+            this.saveloadPanel = new System.Windows.Forms.Panel();
+            this.saveXmlButton = new System.Windows.Forms.Button();
+            this.loadXmlButton = new System.Windows.Forms.Button();
             this.topPanel = new System.Windows.Forms.Panel();
             this.bottomPanel = new System.Windows.Forms.Panel();
             this.flowLayoutPanel.SuspendLayout();
+            this.saveloadPanel.SuspendLayout();
             this.topPanel.SuspendLayout();
             this.bottomPanel.SuspendLayout();
             this.SuspendLayout();
@@ -63,6 +67,7 @@
             this.flowLayoutPanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.flowLayoutPanel.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
             this.flowLayoutPanel.Controls.Add(this.createPanelButton);
+            this.flowLayoutPanel.Controls.Add(this.saveloadPanel);
             this.flowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             this.flowLayoutPanel.Location = new System.Drawing.Point(0, 0);
@@ -84,6 +89,45 @@
             this.createPanelButton.Text = "Add link";
             this.createPanelButton.UseVisualStyleBackColor = true;
             this.createPanelButton.Click += new System.EventHandler(this.createPanelButton_Click);
+            // 
+            // saveloadPanel
+            // 
+            this.saveloadPanel.Controls.Add(this.saveXmlButton);
+            this.saveloadPanel.Controls.Add(this.loadXmlButton);
+            this.saveloadPanel.Location = new System.Drawing.Point(3, 129);
+            this.saveloadPanel.Name = "saveloadPanel";
+            this.saveloadPanel.Size = new System.Drawing.Size(115, 120);
+            this.saveloadPanel.TabIndex = 20;
+            // 
+            // saveXmlButton
+            // 
+            this.saveXmlButton.FlatAppearance.BorderColor = System.Drawing.Color.White;
+            this.saveXmlButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.saveXmlButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.saveXmlButton.ForeColor = System.Drawing.Color.White;
+            this.saveXmlButton.Location = new System.Drawing.Point(0, 0);
+            this.saveXmlButton.MinimumSize = new System.Drawing.Size(80, 30);
+            this.saveXmlButton.Name = "saveXmlButton";
+            this.saveXmlButton.Size = new System.Drawing.Size(115, 57);
+            this.saveXmlButton.TabIndex = 18;
+            this.saveXmlButton.Text = "Save File";
+            this.saveXmlButton.UseVisualStyleBackColor = true;
+            this.saveXmlButton.Click += new System.EventHandler(this.saveXmlButton_Click);
+            // 
+            // loadXmlButton
+            // 
+            this.loadXmlButton.FlatAppearance.BorderColor = System.Drawing.Color.White;
+            this.loadXmlButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.loadXmlButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.loadXmlButton.ForeColor = System.Drawing.Color.White;
+            this.loadXmlButton.Location = new System.Drawing.Point(0, 63);
+            this.loadXmlButton.MinimumSize = new System.Drawing.Size(80, 30);
+            this.loadXmlButton.Name = "loadXmlButton";
+            this.loadXmlButton.Size = new System.Drawing.Size(115, 57);
+            this.loadXmlButton.TabIndex = 19;
+            this.loadXmlButton.Text = "Load File";
+            this.loadXmlButton.UseVisualStyleBackColor = true;
+            this.loadXmlButton.Click += new System.EventHandler(this.loadXmlButton_Click);
             // 
             // topPanel
             // 
@@ -122,7 +166,9 @@
             this.Text = "Account LookUp";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form1_FormClosing);
             this.Load += new System.EventHandler(this.Form1_Load);
+            this.Resize += new System.EventHandler(this.Form1_Resize);
             this.flowLayoutPanel.ResumeLayout(false);
+            this.saveloadPanel.ResumeLayout(false);
             this.topPanel.ResumeLayout(false);
             this.bottomPanel.ResumeLayout(false);
             this.ResumeLayout(false);
@@ -135,6 +181,9 @@
         private System.Windows.Forms.Button createPanelButton;
         public System.Windows.Forms.FlowLayoutPanel flowLayoutPanel;
         public System.Windows.Forms.Panel topPanel;
+        private System.Windows.Forms.Button saveXmlButton;
+        private System.Windows.Forms.Button loadXmlButton;
+        private System.Windows.Forms.Panel saveloadPanel;
     }
 }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,17 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
+using System.Drawing.Text;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Diagnostics;
-using System.Xml;
-using System.IO;
-using System.Reflection;
-using System.Xml.Linq;
 using EzLaunchr.Scripts;
 
 namespace EzLaunchr
@@ -22,12 +12,12 @@ namespace EzLaunchr
         XMLHandler xmlHandler = new XMLHandler();
 
 
+            PrivateFontCollection myfontCollection = new PrivateFontCollection();
         public Form1()
         {
             form1 = this;
             InitializeComponent();
             this.flowLayoutPanel.AllowDrop = true;
-
         }
 
         private void createPanelButton_Click(object sender, EventArgs e)
@@ -46,17 +36,35 @@ namespace EzLaunchr
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)
         {
-            xmlHandler.HandleXMLSave(flowLayoutPanel);
+            //Can perform checks to figure out of the user leaves without saving changes
         }
 
         private void Form1_Load(object sender, EventArgs e)
         {
-            xmlHandler.HandleXMLLoad(flowLayoutPanel);
+            xmlHandler.HandleXMLLoad(flowLayoutPanel,false);
         }
 
-        private void flowLayoutPanel_Paint(object sender, PaintEventArgs e)
+        private void saveXmlButton_Click(object sender, EventArgs e)
         {
+            xmlHandler.HandleXMLSave(flowLayoutPanel);
+        }
 
+
+        //Hiding the panel that holds the Save XML and Load XML buttons to reduce visual clutter
+        private void Form1_Resize(object sender, EventArgs e)
+        {
+            if (flowLayoutPanel.Controls.Count > 2) //This check is used in order to determine if there are more than 2 children in the flowlayoutpanel. If there are NOT we do not hide the save nad load buttons. This means that the user didn't add anything yet
+            {
+                if (this.Width <= 280)
+                    saveloadPanel.Visible = false;
+                else
+                    saveloadPanel.Visible = true;
+            }
+        }
+
+        private void loadXmlButton_Click(object sender, EventArgs e)
+        {
+            xmlHandler.HandleXMLLoad(flowLayoutPanel,true); //It loads another xml file
         }
     }
 }

--- a/Form2.Designer.cs
+++ b/Form2.Designer.cs
@@ -66,9 +66,9 @@
             this.label1.ForeColor = System.Drawing.Color.White;
             this.label1.Location = new System.Drawing.Point(21, 48);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(32, 16);
+            this.label1.Size = new System.Drawing.Size(120, 16);
             this.label1.TabIndex = 2;
-            this.label1.Text = "Link";
+            this.label1.Text = "Link or Full file path";
             // 
             // label2
             // 
@@ -112,6 +112,7 @@
             // 
             // Form2
             // 
+            this.AcceptButton = this.addEntryButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(30)))), ((int)(((byte)(30)))));
@@ -122,6 +123,7 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.descriptionTextBox);
             this.Controls.Add(this.linkTextBox);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximumSize = new System.Drawing.Size(230, 300);
             this.MinimumSize = new System.Drawing.Size(230, 300);

--- a/Form2.cs
+++ b/Form2.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using EzLaunchr.Properties;
 

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -46,7 +46,7 @@
     
     mimetype: application/x-microsoft.net.object.binary.base64
     value   : The object must be serialized with 
-            : System.Serialization.Formatters.Binary.BinaryFormatter
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
@@ -60,6 +60,7 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -68,9 +69,10 @@
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" />
+              <xsd:attribute name="name" use="required" type="xsd:string" />
               <xsd:attribute name="type" type="xsd:string" />
               <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
@@ -85,9 +87,10 @@
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -109,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Scripts/LinkButton.cs
+++ b/Scripts/LinkButton.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿/*
+ * This class is responsible for creating the Buttons containing the links
+ */
+
+using System;
 using System.Windows.Forms;
 using System.Drawing;
 using System.ComponentModel;
@@ -91,22 +91,27 @@ namespace EzLaunchr
 
 
 
-
             //Adding all the controls on top of the panel
             this.Controls.Add(removeButton);
             this.Controls.Add(editButton);
             this.Controls.Add(displayName);
             this.Controls.Add(topPanel);
         }
+        
+        //Will be called when we want to dispose a button
+        public void UnsbscribeFromAllEvents() 
+        {
 
+            displayName.Click -= displayName_Click;
+            removeButton.Click -= removeButton_Click;
+            editButton.Click -= editButton_Click;
+            this.Click -= LinkButton_Click;
+        }
 
         private void removeButton_Click(object sender, EventArgs e)
         {
             //Removing all event handlers before disposing the button
-
-            displayName.Click -= displayName_Click;
-            removeButton.Click -= removeButton_Click;
-            this.Click -= LinkButton_Click;
+            UnsbscribeFromAllEvents();
 
             this.Dispose();
         }
@@ -129,7 +134,7 @@ namespace EzLaunchr
         }
         
 
-        // Opens link in default browser
+        // Opens link in default browser or launches the desired application
         public void OpenLink()
         {
             Console.WriteLine("Redirecting to: " + link);
@@ -157,20 +162,13 @@ namespace EzLaunchr
                     Console.WriteLine("Exception: " + i.Message + " when trying to find link to follow");
                     string messageBoxMessage = "There was a problem following the link when pressing the button." +
                         "\nThis usually occurs when there was no link attached to the button." +
-                        "\nPlease delete and recreate the problematic button.";
+                        "\nPlease edit or delete and recreate the problematic button.";
                     MessageBox.Show(messageBoxMessage, "Link is missing", MessageBoxButtons.OK);
                     return;
                 }
 
                 throw;
             }
-        }
-
-        private void InitializeComponent()
-        {
-            this.SuspendLayout();
-            this.ResumeLayout(false);
-
         }
     }
 }


### PR DESCRIPTION
Buttons with no description are correctly loaded when loading a .xml file. 
Users can save and load a new .xml while the application is running. 
Closing the main application form no longer opens the save dialogue. Users need to save manually 
Changed the main form UI a tiny bit. Added the save/load buttons and when the user shrinks the form those buttons disappear.
Cleaned up some code and added some comments